### PR TITLE
Resolve promise if xhr status code is between 200 and 399, else reject

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -60,7 +60,11 @@ merge(Request.prototype, {
 
     var promise = new Promise(function(resolve, reject) {
       xhr.addEventListener('load', function() {
-        resolve(new Response(xhr));
+        if (xhr.status >= 200 && xhr.status <= 399) {
+          resolve(new Response(xhr));
+        } else {
+          reject(new Response(xhr));
+        }
       });
 
       xhr.addEventListener('error', function() {


### PR DESCRIPTION
The `load` event is triggered regardless of the server response code. An `error` event is triggered if the request fails (like when a connection is unavailable).

With the changes in this PR, we'll only resolve the promise if the response status code is between `200` and `399.` Otherwise, we'll reject the promise.
